### PR TITLE
Add subdomain to mailing list address example.

### DIFF
--- a/docs/replit.md
+++ b/docs/replit.md
@@ -31,7 +31,7 @@ It also does not solve the problem with embeddable non-assignment Repls as these
 The following are the steps to begin using Repl.it in a new class.
 
 1. Confirm with program leadership that the course does not have a preexisting Repl.it account.
-1. Email the technology lead (currently Justin Wolford wolfordj@oregonstate.edu) asking for a **mailing list** to be created for the course. It will be of the form `coe_cs[course number]@oregonstate.edu`.
+1. Email the technology lead (currently Justin Wolford wolfordj@oregonstate.edu) asking for a **mailing list** to be created for the course. It will be of the form `coe_cs[course number]@engr.oregonstate.edu`.
 1. Make sure you sign up for and become an administrator of the mailing list.
   - This should be handled for you when the mailing list is created for you.
   - You can confirm you are an admin of the list by accessing `https://secure.engr.oregonstate.edu/mailman/admin/YOUR_MAILING_LIST`. If you can log into this page you are an administrator.


### PR DESCRIPTION
From @oregonstate.edu to @engr.oregonstate.edu, per the official listserv information.